### PR TITLE
Add proxy for private instance methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ class MyClass
     public function __construct()
     {
         take('HELLO')
-            ->pipe(Closure::fromCallable([$this, 'lowercase']))
+            ->pipe($this)->lowercase()
             ->get();
 
         // "hello"

--- a/src/Item.php
+++ b/src/Item.php
@@ -40,7 +40,7 @@ class Item
      * @param callable|string|object $callback
      * @param array ...$arguments
      *
-     * @return \SebastiaanLuca\PipeOperator\Item $this
+     * @return \SebastiaanLuca\PipeOperator\Item|\SebastiaanLuca\PipeOperator\PipeProxy
      */
     public function pipe($callback, ...$arguments)
     {
@@ -59,11 +59,12 @@ class Item
      * Add the given value to the list of arguments.
      *
      * @param  array $arguments
+     *
      * @return array
      */
     public function addValueToArguments(array $arguments) : array
     {
-        // If the caller hasn't explicitely specified where they want the value
+        // If the caller hasn't explicitly specified where they want the value
         // to be added, we will add it as the first value. Otherwise we will
         // replace all occurrences of PIPED_VALUE with the original value.
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -37,32 +37,43 @@ class Item
     /**
      * Perform an operation on the current value.
      *
-     * @param callable|string $callback
+     * @param callable|string|object $callback
      * @param array ...$arguments
      *
      * @return \SebastiaanLuca\PipeOperator\Item $this
      */
     public function pipe($callback, ...$arguments)
     {
-        // No explicit use of the value identifier means it should be the first
-        //argument to call the method with. If it does get used though, we should
-        // replace any occurrence of it with the actual value.
-
-        if (! in_array(PIPED_VALUE, $arguments, true)) {
-            // Add the given item value as first parameter to call the pipe method with
-            array_unshift($arguments, $this->value);
-        }
-        else {
-            $arguments = array_map(function ($argument) {
-                return $argument === PIPED_VALUE ? $this->value : $argument;
-            }, $arguments);
+        if (! is_callable($callback)) {
+            return new PipeProxy($this, $callback);
         }
 
         // Call the piped method
-        $this->value = $callback(...$arguments);
+        $this->value = $callback(...$this->addValueToArguments($arguments));
 
         // Allow method chaining
         return $this;
+    }
+
+    /**
+     * Add the given value to the list of arguments.
+     *
+     * @param  array $arguments
+     * @return array
+     */
+    public function addValueToArguments(array $arguments) : array
+    {
+        // If the caller hasn't explicitely specified where they want the value
+        // to be added, we will add it as the first value. Otherwise we will
+        // replace all occurrences of PIPED_VALUE with the original value.
+
+        if (! in_array(PIPED_VALUE, $arguments, true)) {
+            return array_merge([$this->value], $arguments);
+        }
+
+        return array_map(function ($argument) {
+            return $argument === PIPED_VALUE ? $this->value : $argument;
+        }, $arguments);
     }
 
     /**

--- a/src/PipeProxy.php
+++ b/src/PipeProxy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SebastiaanLuca\PipeOperator;
+
+use Closure;
+
+class PipeProxy
+{
+    /**
+     * @param \SebastiaanLuca\PipeOperator\Item $item
+     * @param object $object
+     */
+    public function __construct(Item $item, $object)
+    {
+        $this->item = $item;
+        $this->object = $object;
+    }
+
+    /**
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return \SebastiaanLuca\PipeOperator\Item $this
+     */
+    public function __call($method, array $arguments)
+    {
+        $callback = Closure::bind(function (...$arguments) use ($method) {
+            return $this->{$method}(...$arguments);
+        }, $this->object, $this->object);
+
+        return $this->item->pipe($callback, ...$arguments);
+    }
+}

--- a/src/PipeProxy.php
+++ b/src/PipeProxy.php
@@ -7,6 +7,16 @@ use Closure;
 class PipeProxy
 {
     /**
+     * @var \SebastiaanLuca\PipeOperator\Item
+     */
+    protected $item;
+
+    /**
+     * @var object
+     */
+    protected $object;
+
+    /**
      * @param \SebastiaanLuca\PipeOperator\Item $item
      * @param object $object
      */

--- a/src/PipeProxy.php
+++ b/src/PipeProxy.php
@@ -30,7 +30,7 @@ class PipeProxy
      * @param string $method
      * @param array $arguments
      *
-     * @return \SebastiaanLuca\PipeOperator\Item $this
+     * @return \SebastiaanLuca\PipeOperator\Item
      */
     public function __call($method, array $arguments)
     {

--- a/tests/Unit/MethodsTest.php
+++ b/tests/Unit/MethodsTest.php
@@ -77,6 +77,20 @@ class MethodsTest extends TestCase
     /**
      * @test
      */
+    public function it can transform a value using a proxied private class method() : void
+    {
+        $this->assertSame(
+            'start-add-this',
+            take('START')
+                ->pipe($this)->join('ADD', 'this')
+                ->pipe($this)->lowercase()
+                ->get()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it can transform a value while accepting pipe parameters() : void
     {
         $this->assertSame(
@@ -118,5 +132,15 @@ class MethodsTest extends TestCase
     private function lowercase(string $value) : string
     {
         return mb_strtolower($value);
+    }
+
+    /**
+     * @param array ...$values
+     *
+     * @return string
+     */
+    private function join(...$values) : string
+    {
+        return implode('-', $values);
     }
 }


### PR DESCRIPTION
## PR Type

What kind of pull request is this?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## What does it change?

You can now more easily pipe calls to private methods on your class:

```php
take($value)
    ->pipe($this)->instanceMethod()
    ->get();
```

## Why this PR?

While`[$this, 'method']` & `Closure::fromCallable` do the trick, they're more verbose, and don't look like a method call. Using a proxy to pipe method calls onto the class looks much nicer.

## How has this been tested?

I added a test in the `MethodTest` class.